### PR TITLE
Fix NameError on requiring gem

### DIFF
--- a/lib/statuscake.rb
+++ b/lib/statuscake.rb
@@ -3,6 +3,6 @@ require 'faraday_middleware'
 
 module StatusCake; end
 
+require 'statuscake/version'
 require 'statuscake/client'
 require 'statuscake/error'
-require 'statuscake/version'


### PR DESCRIPTION
I found a bug when requiring the gem when not using bundler, client.rb NameErrors because version hasn't been required yet, reordering the requires fixed it.
